### PR TITLE
Use capability filter for settings

### DIFF
--- a/src/inc/settings.php
+++ b/src/inc/settings.php
@@ -527,7 +527,7 @@ function ableplayer_menu() {
 	add_options_page(
 		__( 'Able Player', 'ableplayer' ),
 		__( 'Able Player', 'ableplayer' ),
-		'manage_options',
+		apply_filters( 'ableplayer_capability', 'manage_options' ),
 		'ableplayer',
 		'ableplayer_settings_form'
 	);


### PR DESCRIPTION
## Description
Add a filter, so you can allow eg. editors to Able Player settings.

## How Has This Been Tested?
By modifying current plugin source locally and with a filter in place. Settings show and are editable for editors.
```php
add_filter(
  'ableplayer_capability',
  static function (): string {
    return 'edit_others_posts';
  }
);
```

## Types of changes
Adds a capability filter

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.9 and PHP 7.0.
- [x] My code follows the WordPress coding standards.
- [x] My code has proper inline documentation.
